### PR TITLE
Added Typescript type definitions

### DIFF
--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -1,0 +1,13 @@
+declare module 'tailbreak' {
+	interface TailbreakBreakpoints {
+		sm: boolean;
+		md: boolean;
+		lg: boolean;
+		xl: boolean;
+		'2xl': boolean;
+	}
+
+	function TailbreakFactory(): TailbreakBreakpoints;
+
+	export = TailbreakFactory;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.1",
   "description": "Lightweight library that let's you detect the current breakpoint of the window from the breakpoints in your tailwind config",
   "main": "./lib/tailbreak.js",
+  "types": "./lib/main.d.ts",
   "files": [
     "/lib"
   ],


### PR DESCRIPTION
I used tailbreak in a pet project and noticed there were no type definitions. Since it's a tiny lib, I figured I could just make some manual types for you.